### PR TITLE
MAID-2864: fix/parsec: fix receeding consensus (WIP)

### DIFF
--- a/src/gossip/event.rs
+++ b/src/gossip/event.rs
@@ -18,6 +18,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{self, Debug, Formatter};
 use vote::Vote;
 
+#[derive(Clone)]
 pub(crate) struct Event<T: NetworkEvent, P: PublicId> {
     content: Content<T, P>,
     // Creator's signature of `content`.


### PR DESCRIPTION
The valid blocks carried don't get recalculated on old gossip events
when clearing the consensus data, which causes consensus to occur later
and later as old events aren't ever again considered as interesting
events.